### PR TITLE
Change getters in Task to return Optionals

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -86,7 +86,10 @@ public class EditCommand extends Command {
                 .orElseGet(taskToEdit::getPriority)
                 .orElse(null);
         Status updatedStatus = editTaskDescriptor.getStatus().orElseGet(taskToEdit::getStatus);
-        Note updatedNote = editTaskDescriptor.getNote().orElseGet(taskToEdit::getNote);
+        Note updatedNote = editTaskDescriptor.getNote()
+                .map(Optional::of)
+                .orElseGet(taskToEdit::getNote)
+                .orElse(null);
         Deadline updatedDeadline = editTaskDescriptor.getDeadline().orElseGet(taskToEdit::getDeadline);
         UniqueTagList updatedTags = editTaskDescriptor.getTags().orElseGet(taskToEdit::getTags);
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -90,7 +90,11 @@ public class EditCommand extends Command {
                 .map(Optional::of)
                 .orElseGet(taskToEdit::getNote)
                 .orElse(null);
-        Deadline updatedDeadline = editTaskDescriptor.getDeadline().orElseGet(taskToEdit::getDeadline);
+        Deadline updatedDeadline = editTaskDescriptor
+                .getDeadline()
+                .map(Optional::of)
+                .orElseGet(taskToEdit::getDeadline)
+                .orElse(null);
         UniqueTagList updatedTags = editTaskDescriptor.getTags().orElseGet(taskToEdit::getTags);
 
         return new Task(updatedName, updatedPriority, updatedStatus, updatedNote, updatedDeadline, updatedTags);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -80,7 +80,11 @@ public class EditCommand extends Command {
         assert taskToEdit != null;
 
         Name updatedName = editTaskDescriptor.getName().orElseGet(taskToEdit::getName);
-        Priority updatedPriority = editTaskDescriptor.getPriority().orElseGet(taskToEdit::getPriority);
+        Priority updatedPriority = editTaskDescriptor
+                .getPriority()
+                .map(Optional::of)
+                .orElseGet(taskToEdit::getPriority)
+                .orElse(null);
         Status updatedStatus = editTaskDescriptor.getStatus().orElseGet(taskToEdit::getStatus);
         Note updatedNote = editTaskDescriptor.getNote().orElseGet(taskToEdit::getNote);
         Deadline updatedDeadline = editTaskDescriptor.getDeadline().orElseGet(taskToEdit::getDeadline);

--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -9,7 +9,28 @@ import seedu.address.commons.exceptions.IllegalValueException;
 public class Priority {
 
     public static enum Type {
-        NONE, HIGH, MEDIUM, LOW;
+
+        NONE,
+        HIGH,
+        MEDIUM,
+        LOW;
+
+        @Override
+        public String toString() {
+            switch(this) {
+            case NONE:
+                return PRIORITY_NONE;
+            case HIGH:
+                return PRIORITY_HIGH;
+            case MEDIUM:
+                return PRIORITY_MEDIUM;
+            case LOW:
+                return PRIORITY_LOW;
+            default:
+                throw new AssertionError();
+            }
+        }
+
     }
 
     public static final String MESSAGE_PRIORITY_CONSTRAINTS = "Task priority can only take specific string "

--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -41,7 +41,7 @@ public class Priority {
     public static final String PRIORITY_LOW = "low";
     public static final String PRIORITY_NONE = "none";
 
-    public final Type value;
+    private final Type value;
 
     /**
      * Validates given priority.
@@ -140,6 +140,13 @@ public class Priority {
         default:
             return false;
         }
+    }
+
+    /**
+     * @return the current value of the priority
+     */
+    public Type getValue() {
+        return value;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/Priority.java
+++ b/src/main/java/seedu/address/model/task/Priority.java
@@ -93,28 +93,6 @@ public class Priority {
         }
     }
 
-    /**
-     * parse a priority into user input string
-     *
-     * @param priority
-     * @return null if invalid
-     */
-    public static String toUserInputString(Type priority) {
-        assert priority != null;
-        switch (priority) {
-        case NONE:
-            return PRIORITY_NONE;
-        case HIGH:
-            return PRIORITY_HIGH;
-        case MEDIUM:
-            return PRIORITY_MEDIUM;
-        case LOW:
-            return PRIORITY_LOW;
-        default:
-            throw new AssertionError();
-        }
-    }
-
     public static Priority.Type parseXmlString(String priority) throws IllegalValueException {
         assert priority != null;
         try {

--- a/src/main/java/seedu/address/model/task/ReadOnlyTask.java
+++ b/src/main/java/seedu/address/model/task/ReadOnlyTask.java
@@ -49,8 +49,11 @@ public interface ReadOnlyTask {
 
         builder.append(" Status: ");
         builder.append(getStatus());
-        builder.append(" Note: ");
-        builder.append(getNote());
+
+        if (getNote().isPresent()) {
+            builder.append(" Note: ").append(getNote().get().toString());
+        }
+
         builder.append(" Deadline: ");
         builder.append(getDeadline().toString());
         builder.append(" Tags: ");

--- a/src/main/java/seedu/address/model/task/ReadOnlyTask.java
+++ b/src/main/java/seedu/address/model/task/ReadOnlyTask.java
@@ -1,5 +1,7 @@
 package seedu.address.model.task;
 
+import java.util.Optional;
+
 import seedu.address.model.tag.UniqueTagList;
 
 /**
@@ -9,7 +11,7 @@ import seedu.address.model.tag.UniqueTagList;
 public interface ReadOnlyTask {
 
     Name getName();
-    Priority getPriority();
+    Optional<Priority> getPriority();
     Status getStatus();
     Note getNote();
     Deadline getDeadline();
@@ -38,16 +40,20 @@ public interface ReadOnlyTask {
      */
     default String getAsText() {
         final StringBuilder builder = new StringBuilder();
-        builder.append(getName())
-                .append(" Priority: ")
-                .append(getPriority())
-                .append(" Status: ")
-                .append(getStatus())
-                .append(" Note: ")
-                .append(getNote())
-                .append(" Deadline: ")
-                .append(getDeadline().toString())
-                .append(" Tags: ");
+
+        builder.append(getName());
+
+        if (getPriority().isPresent()) {
+            builder.append(" Priority: ").append(getPriority().get().toString());
+        }
+
+        builder.append(" Status: ");
+        builder.append(getStatus());
+        builder.append(" Note: ");
+        builder.append(getNote());
+        builder.append(" Deadline: ");
+        builder.append(getDeadline().toString());
+        builder.append(" Tags: ");
         getTags().forEach(builder::append);
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/task/ReadOnlyTask.java
+++ b/src/main/java/seedu/address/model/task/ReadOnlyTask.java
@@ -13,7 +13,7 @@ public interface ReadOnlyTask {
     Name getName();
     Optional<Priority> getPriority();
     Status getStatus();
-    Note getNote();
+    Optional<Note> getNote();
     Deadline getDeadline();
 
     /**

--- a/src/main/java/seedu/address/model/task/ReadOnlyTask.java
+++ b/src/main/java/seedu/address/model/task/ReadOnlyTask.java
@@ -14,7 +14,7 @@ public interface ReadOnlyTask {
     Optional<Priority> getPriority();
     Status getStatus();
     Optional<Note> getNote();
-    Deadline getDeadline();
+    Optional<Deadline> getDeadline();
 
     /**
      * The returned TagList is a deep copy of the internal TagList,
@@ -54,8 +54,10 @@ public interface ReadOnlyTask {
             builder.append(" Note: ").append(getNote().get().toString());
         }
 
-        builder.append(" Deadline: ");
-        builder.append(getDeadline().toString());
+        if (getDeadline().isPresent()) {
+            builder.append(" Deadline: ").append(getDeadline().get().toString());
+        }
+
         builder.append(" Tags: ");
         getTags().forEach(builder::append);
         return builder.toString();

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -1,6 +1,7 @@
 package seedu.address.model.task;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.model.tag.UniqueTagList;
@@ -40,7 +41,7 @@ public class Task implements ReadOnlyTask {
      * Creates a copy of the given ReadOnlyTask.
      */
     public Task(ReadOnlyTask source) {
-        this(source.getName(), source.getPriority(), source.getStatus(),
+        this(source.getName(), source.getPriority().orElse(null), source.getStatus(),
                 source.getNote(), source.getDeadline(), source.getTags());
     }
 
@@ -60,8 +61,8 @@ public class Task implements ReadOnlyTask {
     }
 
     @Override
-    public Priority getPriority() {
-        return priority;
+    public Optional<Priority> getPriority() {
+        return Optional.of(priority);
     }
 
     public void setStatus(Status status) {
@@ -112,7 +113,7 @@ public class Task implements ReadOnlyTask {
         assert replacement != null;
 
         this.setName(replacement.getName());
-        this.setPriority(replacement.getPriority());
+        this.setPriority(replacement.getPriority().orElse(null));
         this.setStatus(replacement.getStatus());
         this.setNote(replacement.getNote());
         this.setDeadline(replacement.getDeadline());

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -23,7 +23,11 @@ public class Task implements ReadOnlyTask {
      * Every field must be present and not null.
      */
     public Task(Name name, Priority priority, Status status, Note note, Deadline deadline, UniqueTagList tags) {
-        assert !CollectionUtil.isAnyNull(name, priority, status, note, tags);
+        // Name should never be null because it is required for each task.
+        // Status should never be null because every created task should be marked as incomplete.
+        // Tags should never be null because zero tags is represented as an empty list.
+        assert !CollectionUtil.isAnyNull(name, status, tags);
+
         this.name = name;
         this.priority = priority;
         this.status = status;

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -115,7 +115,7 @@ public class Task implements ReadOnlyTask {
         this.setName(replacement.getName());
         this.setPriority(replacement.getPriority().orElse(null));
         this.setStatus(replacement.getStatus());
-        this.setNote(replacement.getNote());
+        this.setNote(replacement.getNote().orElse(null));
         this.setDeadline(replacement.getDeadline());
         this.setTags(replacement.getTags());
     }

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -42,7 +42,7 @@ public class Task implements ReadOnlyTask {
      */
     public Task(ReadOnlyTask source) {
         this(source.getName(), source.getPriority().orElse(null), source.getStatus(),
-                source.getNote(), source.getDeadline(), source.getTags());
+                source.getNote().orElse(null), source.getDeadline(), source.getTags());
     }
 
     public void setName(Name name) {
@@ -81,8 +81,8 @@ public class Task implements ReadOnlyTask {
     }
 
     @Override
-    public Note getNote() {
-        return note;
+    public Optional<Note> getNote() {
+        return Optional.of(note);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -42,7 +42,7 @@ public class Task implements ReadOnlyTask {
      */
     public Task(ReadOnlyTask source) {
         this(source.getName(), source.getPriority().orElse(null), source.getStatus(),
-                source.getNote().orElse(null), source.getDeadline(), source.getTags());
+                source.getNote().orElse(null), source.getDeadline().orElse(null), source.getTags());
     }
 
     public void setName(Name name) {
@@ -86,8 +86,8 @@ public class Task implements ReadOnlyTask {
     }
 
     @Override
-    public Deadline getDeadline() {
-        return deadline;
+    public Optional<Deadline> getDeadline() {
+        return Optional.of(deadline);
     }
 
     public void setDeadline(Deadline deadline) {
@@ -116,7 +116,7 @@ public class Task implements ReadOnlyTask {
         this.setPriority(replacement.getPriority().orElse(null));
         this.setStatus(replacement.getStatus());
         this.setNote(replacement.getNote().orElse(null));
-        this.setDeadline(replacement.getDeadline());
+        this.setDeadline(replacement.getDeadline().orElse(null));
         this.setTags(replacement.getTags());
     }
 

--- a/src/main/java/seedu/address/storage/XmlAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedTask.java
@@ -55,7 +55,7 @@ public class XmlAdaptedTask {
                 .orElse(Priority.Type.NONE.name());
         status = source.getStatus().value;
         note = source.getNote().map(Note::toString).orElse("");
-        deadline = source.getDeadline().toString();
+        deadline = source.getDeadline().map(Deadline::toString).orElse("");
         tagged = new ArrayList<>();
         for (Tag tag : source.getTags()) {
             tagged.add(new XmlAdaptedTag(tag));

--- a/src/main/java/seedu/address/storage/XmlAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedTask.java
@@ -49,7 +49,10 @@ public class XmlAdaptedTask {
      */
     public XmlAdaptedTask(ReadOnlyTask source) {
         name = source.getName().fullName;
-        priority = source.getPriority().value.toString();
+        priority = source.getPriority()
+                .map(Priority::getValue)
+                .map(Priority.Type::name)
+                .orElse(Priority.Type.NONE.name());
         status = source.getStatus().value;
         note = source.getNote().value;
         deadline = source.getDeadline().toString();

--- a/src/main/java/seedu/address/storage/XmlAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedTask.java
@@ -54,7 +54,7 @@ public class XmlAdaptedTask {
                 .map(Priority.Type::name)
                 .orElse(Priority.Type.NONE.name());
         status = source.getStatus().value;
-        note = source.getNote().value;
+        note = source.getNote().map(Note::toString).orElse("");
         deadline = source.getDeadline().toString();
         tagged = new ArrayList<>();
         for (Tag tag : source.getTags()) {

--- a/src/main/java/seedu/address/ui/TaskCard.java
+++ b/src/main/java/seedu/address/ui/TaskCard.java
@@ -5,6 +5,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import seedu.address.model.task.Priority;
 import seedu.address.model.task.ReadOnlyTask;
 
 public class TaskCard extends UiPart<Region> {
@@ -32,7 +33,7 @@ public class TaskCard extends UiPart<Region> {
         super(FXML);
         name.setText(task.getName().fullName);
         id.setText(displayedIndex + ". ");
-        priority.setText(task.getPriority().value.toString());
+        priority.setText(task.getPriority().map(Priority::toString).orElse(""));
         note.setText(task.getNote().value);
         status.setText(task.getStatus().value);
         deadline.setText(task.getDeadline().toString());

--- a/src/main/java/seedu/address/ui/TaskCard.java
+++ b/src/main/java/seedu/address/ui/TaskCard.java
@@ -5,6 +5,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import seedu.address.model.task.Note;
 import seedu.address.model.task.Priority;
 import seedu.address.model.task.ReadOnlyTask;
 
@@ -34,7 +35,7 @@ public class TaskCard extends UiPart<Region> {
         name.setText(task.getName().fullName);
         id.setText(displayedIndex + ". ");
         priority.setText(task.getPriority().map(Priority::toString).orElse(""));
-        note.setText(task.getNote().value);
+        note.setText(task.getNote().map(Note::toString).orElse(""));
         status.setText(task.getStatus().value);
         deadline.setText(task.getDeadline().toString());
         initTags(task);

--- a/src/main/java/seedu/address/ui/TaskCard.java
+++ b/src/main/java/seedu/address/ui/TaskCard.java
@@ -5,6 +5,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import seedu.address.model.task.Deadline;
 import seedu.address.model.task.Note;
 import seedu.address.model.task.Priority;
 import seedu.address.model.task.ReadOnlyTask;
@@ -37,7 +38,7 @@ public class TaskCard extends UiPart<Region> {
         priority.setText(task.getPriority().map(Priority::toString).orElse(""));
         note.setText(task.getNote().map(Note::toString).orElse(""));
         status.setText(task.getStatus().value);
-        deadline.setText(task.getDeadline().toString());
+        deadline.setText(task.getDeadline().map(Deadline::toString).orElse(""));
         initTags(task);
     }
 

--- a/src/test/java/guitests/guihandles/TaskCardHandle.java
+++ b/src/test/java/guitests/guihandles/TaskCardHandle.java
@@ -9,6 +9,7 @@ import javafx.scene.control.Labeled;
 import javafx.scene.layout.Region;
 import javafx.stage.Stage;
 import seedu.address.model.tag.UniqueTagList;
+import seedu.address.model.task.Note;
 import seedu.address.model.task.Priority;
 import seedu.address.model.task.ReadOnlyTask;
 
@@ -77,7 +78,7 @@ public class TaskCardHandle extends GuiHandle {
         return getFullName().equals(task.getName().fullName)
                 && getPriority().equals(task.getPriority().map(Priority::toString).orElse(""))
                 && getStatus().equals(task.getStatus().value)
-                && getNote().equals(task.getNote().value)
+                && getNote().equals(task.getNote().map(Note::toString).orElse(""))
                 && getTags().equals(getTags(task.getTags()));
     }
 

--- a/src/test/java/guitests/guihandles/TaskCardHandle.java
+++ b/src/test/java/guitests/guihandles/TaskCardHandle.java
@@ -9,6 +9,7 @@ import javafx.scene.control.Labeled;
 import javafx.scene.layout.Region;
 import javafx.stage.Stage;
 import seedu.address.model.tag.UniqueTagList;
+import seedu.address.model.task.Priority;
 import seedu.address.model.task.ReadOnlyTask;
 
 /**
@@ -74,7 +75,7 @@ public class TaskCardHandle extends GuiHandle {
 
     public boolean isSameTask(ReadOnlyTask task) {
         return getFullName().equals(task.getName().fullName)
-                && getPriority().equals(task.getPriority().toString())
+                && getPriority().equals(task.getPriority().map(Priority::toString).orElse(""))
                 && getStatus().equals(task.getStatus().value)
                 && getNote().equals(task.getNote().value)
                 && getTags().equals(getTags(task.getTags()));

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -469,7 +469,9 @@ public class LogicManagerTest {
                 cmd.append(" n/").append(p.getNote().get().toString());
             }
 
-            cmd.append(" d/").append(p.getDeadline().toString());
+            if (p.getDeadline().isPresent()) {
+                cmd.append(" d/").append(p.getDeadline().get().toString());
+            }
 
             UniqueTagList tags = p.getTags();
             for (Tag t: tags) {

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -460,7 +460,11 @@ public class LogicManagerTest {
 
             cmd.append(p.getName().toString());
             cmd.append(" s/").append(p.getStatus());
-            cmd.append(" p/").append(Priority.toUserInputString(p.getPriority().value));
+
+            if (p.getPriority().isPresent()) {
+                cmd.append(" p/").append(p.getPriority().get().toString());
+            }
+
             cmd.append(" n/").append(p.getNote());
             cmd.append(" d/").append(p.getDeadline().toString());
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -465,7 +465,10 @@ public class LogicManagerTest {
                 cmd.append(" p/").append(p.getPriority().get().toString());
             }
 
-            cmd.append(" n/").append(p.getNote());
+            if (p.getNote().isPresent()) {
+                cmd.append(" n/").append(p.getNote().get().toString());
+            }
+
             cmd.append(" d/").append(p.getDeadline().toString());
 
             UniqueTagList tags = p.getTags();

--- a/src/test/java/seedu/address/model/task/PriorityTest.java
+++ b/src/test/java/seedu/address/model/task/PriorityTest.java
@@ -32,7 +32,7 @@ public class PriorityTest {
     @Test (expected = IllegalValueException.class)
     public void initialisePriorityWithInvalidArgs() throws IllegalValueException {
         @SuppressWarnings("unused")
-        Priority invalidPriority = new Priority("invalid");
+        Priority invalidPriority = new Priority("HIGH");
     }
 
     @Test
@@ -50,15 +50,10 @@ public class PriorityTest {
 
     @Test
     public void toUserInputString() {
-        assertEquals(Priority.toUserInputString(Type.NONE), Priority.PRIORITY_NONE);
-        assertEquals(Priority.toUserInputString(Type.HIGH), Priority.PRIORITY_HIGH);
-        assertEquals(Priority.toUserInputString(Type.MEDIUM), Priority.PRIORITY_MEDIUM);
-        assertEquals(Priority.toUserInputString(Type.LOW), Priority.PRIORITY_LOW);
-    }
-
-    @Test (expected = AssertionError.class)
-    public void toUserInputStringWithInvalidArgs() {
-        Priority.toUserInputString(null);
+        assertEquals(Type.NONE.toString(), Priority.PRIORITY_NONE);
+        assertEquals(Type.HIGH.toString(), Priority.PRIORITY_HIGH);
+        assertEquals(Type.MEDIUM.toString(), Priority.PRIORITY_MEDIUM);
+        assertEquals(Type.LOW.toString(), Priority.PRIORITY_LOW);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TestTask.java
+++ b/src/test/java/seedu/address/testutil/TestTask.java
@@ -78,8 +78,8 @@ public class TestTask implements ReadOnlyTask {
     }
 
     @Override
-    public Note getNote() {
-        return note;
+    public Optional<Note> getNote() {
+        return Optional.of(note);
     }
 
     @Override

--- a/src/test/java/seedu/address/testutil/TestTask.java
+++ b/src/test/java/seedu/address/testutil/TestTask.java
@@ -110,7 +110,11 @@ public class TestTask implements ReadOnlyTask {
         }
 
         sb.append("s/" + this.getStatus().value + " ");
-        sb.append("d/" + this.getDeadline().toString() + " ");
+
+        if (this.getDeadline().isPresent()) {
+            sb.append("d/" + this.getDeadline().get().toString() + " ");
+        }
+
         this.getTags().asObservableList().stream().forEach(s -> sb.append("t/" + s.tagName + " "));
         return sb.toString();
     }

--- a/src/test/java/seedu/address/testutil/TestTask.java
+++ b/src/test/java/seedu/address/testutil/TestTask.java
@@ -33,7 +33,7 @@ public class TestTask implements ReadOnlyTask {
         this.name = taskToCopy.getName();
         this.priority = taskToCopy.getPriority().orElse(null);
         this.status = taskToCopy.getStatus();
-        this.note = taskToCopy.getNote();
+        this.note = taskToCopy.getNote().orElse(null);
         this.deadline = taskToCopy.getDeadline();
         this.tags = taskToCopy.getTags();
     }

--- a/src/test/java/seedu/address/testutil/TestTask.java
+++ b/src/test/java/seedu/address/testutil/TestTask.java
@@ -100,7 +100,10 @@ public class TestTask implements ReadOnlyTask {
     public String getAddCommand() {
         StringBuilder sb = new StringBuilder();
         sb.append("add " + this.getName().fullName + " ");
-        sb.append("n/" + this.getNote().value + " ");
+
+        if (this.getNote().isPresent()) {
+            sb.append("n/" + this.getNote().get().toString() + " ");
+        }
 
         if (this.getPriority().isPresent()) {
             sb.append("p/" + this.getPriority().get().toString());

--- a/src/test/java/seedu/address/testutil/TestTask.java
+++ b/src/test/java/seedu/address/testutil/TestTask.java
@@ -1,5 +1,7 @@
 package seedu.address.testutil;
 
+import java.util.Optional;
+
 import seedu.address.model.tag.UniqueTagList;
 import seedu.address.model.task.Deadline;
 import seedu.address.model.task.Name;
@@ -29,7 +31,7 @@ public class TestTask implements ReadOnlyTask {
      */
     public TestTask(TestTask taskToCopy) {
         this.name = taskToCopy.getName();
-        this.priority = taskToCopy.getPriority();
+        this.priority = taskToCopy.getPriority().orElse(null);
         this.status = taskToCopy.getStatus();
         this.note = taskToCopy.getNote();
         this.deadline = taskToCopy.getDeadline();
@@ -66,8 +68,8 @@ public class TestTask implements ReadOnlyTask {
     }
 
     @Override
-    public Priority getPriority() {
-        return priority;
+    public Optional<Priority> getPriority() {
+        return Optional.of(priority);
     }
 
     @Override
@@ -99,7 +101,11 @@ public class TestTask implements ReadOnlyTask {
         StringBuilder sb = new StringBuilder();
         sb.append("add " + this.getName().fullName + " ");
         sb.append("n/" + this.getNote().value + " ");
-        sb.append("p/" + Priority.toUserInputString(this.getPriority().value) + " ");
+
+        if (this.getPriority().isPresent()) {
+            sb.append("p/" + this.getPriority().get().toString());
+        }
+
         sb.append("s/" + this.getStatus().value + " ");
         sb.append("d/" + this.getDeadline().toString() + " ");
         this.getTags().asObservableList().stream().forEach(s -> sb.append("t/" + s.tagName + " "));

--- a/src/test/java/seedu/address/testutil/TestTask.java
+++ b/src/test/java/seedu/address/testutil/TestTask.java
@@ -34,7 +34,7 @@ public class TestTask implements ReadOnlyTask {
         this.priority = taskToCopy.getPriority().orElse(null);
         this.status = taskToCopy.getStatus();
         this.note = taskToCopy.getNote().orElse(null);
-        this.deadline = taskToCopy.getDeadline();
+        this.deadline = taskToCopy.getDeadline().orElse(null);
         this.tags = taskToCopy.getTags();
     }
 
@@ -83,8 +83,8 @@ public class TestTask implements ReadOnlyTask {
     }
 
     @Override
-    public Deadline getDeadline() {
-        return deadline;
+    public Optional<Deadline> getDeadline() {
+        return Optional.of(deadline);
     }
 
     @Override


### PR DESCRIPTION
## Changes

These methods now returns an `Optional` instead of an actual value
- `getPriority`
- `getNote`
- `getDeadline`

It is now valid to pass `null` to the constructors. e.g. If a `Task` does not have a `Deadline`, simply pass in `null` to the constructor argument.

This makes it easier for us to handle situations where `Task` does not have a priority, note or deadline.

## TODO

- [ ] Explore choices to use `Optional.ofNullable` instead
- [ ] XML storage still has all required fields now, we can change some of them to be non-compulsory so we do not have to input a default value to the XML storage
- [ ] Test coverage, potentially

Let me know if you are comfortable with these changes, if not we can discuss this further. :smile: