### PR TITLE
Stubbed LocalDateTime for DateTime unit tests

### DIFF
--- a/src/main/java/seedu/opus/model/task/DateTime.java
+++ b/src/main/java/seedu/opus/model/task/DateTime.java
@@ -1,7 +1,9 @@
 package seedu.opus.model.task;
 
 import java.time.Clock;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.ResolverStyle;
 
@@ -54,8 +56,12 @@ public class DateTime {
         // 1 for Monday, 7 for Sunday
         int dayOfCurrentWeek = now.getDayOfWeek().getValue();
 
-        LocalDateTime startOfWeek = now.minusDays(dayOfCurrentWeek);
-        LocalDateTime endOfWeek = now.plusDays(7 - dayOfCurrentWeek);
+        // We take last Sunday and next Monday because isAfter and isBefore methods are not inclusive.
+        LocalDate lastSundayDate = now.minusDays(dayOfCurrentWeek - 2).toLocalDate();
+        LocalDate nextMondayDate = now.plusDays(8 - dayOfCurrentWeek).toLocalDate();
+
+        LocalDateTime startOfWeek = LocalDateTime.of(lastSundayDate, LocalTime.MAX);
+        LocalDateTime endOfWeek = LocalDateTime.of(nextMondayDate, LocalTime.MIDNIGHT);
 
         return dateTime.isAfter(startOfWeek) && dateTime.isBefore(endOfWeek);
     }

--- a/src/test/java/seedu/opus/model/task/DateTimeTest.java
+++ b/src/test/java/seedu/opus/model/task/DateTimeTest.java
@@ -5,7 +5,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.time.Clock;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 
 import org.junit.Test;
@@ -25,36 +27,39 @@ public class DateTimeTest {
 
     @Test
     public void isInCurrentWeek() {
-        LocalDateTime now = LocalDateTime.now();
-        Clock fixedClock = Clock.fixed(now.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
+        // Stub the time now to be 10:30AM on 2017-03-22, Wednesday.
+        LocalDateTime stubbedNow = LocalDateTime.of(LocalDate.of(2017, 3, 22), LocalTime.of(10, 30));
+        Clock fixedClock = Clock.fixed(stubbedNow.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
 
         try {
             // Today should be in current week
-            DateTime today = new DateTime(now);
+            DateTime today = new DateTime(stubbedNow);
             today.setClock(fixedClock);
             assertTrue(today.isCurrentWeek());
 
-            // Next week is not in current week
-            DateTime nextWeek = new DateTime(now.plusDays(7));
-            nextWeek.setClock(fixedClock);
-            assertFalse(nextWeek.isCurrentWeek());
-
             // This Sunday should be in current week
-            int daysToSunday = 7 - now.getDayOfWeek().getValue() - 1;
-            DateTime sunday = new DateTime(now.plusDays(daysToSunday));
+            LocalDateTime stubbedSunday = LocalDateTime.of(LocalDate.of(2017, 3, 26), LocalTime.MAX);
+            DateTime sunday = new DateTime(stubbedSunday);
             sunday.setClock(fixedClock);
             assertTrue(sunday.isCurrentWeek());
 
             // Next Monday should not be in current week
-            DateTime nextMonday = new DateTime(now.plusDays(daysToSunday + 1));
+            LocalDateTime stubbedNextMonday = LocalDateTime.of(LocalDate.of(2017, 3, 27), LocalTime.MIDNIGHT);
+            DateTime nextMonday = new DateTime(stubbedNextMonday);
             nextMonday.setClock(fixedClock);
             assertFalse(nextMonday.isCurrentWeek());
 
+            // This Monday should be in current week
+            LocalDateTime stubbedMonday = LocalDateTime.of(LocalDate.of(2017, 3, 20), LocalTime.MIDNIGHT);
+            DateTime monday = new DateTime(stubbedMonday);
+            monday.setClock(fixedClock);
+            assertFalse(monday.isCurrentWeek());
+
             // Last Sunday should not be in current week
-            DateTime lastSunday = new DateTime(now.minusDays(now.getDayOfWeek().getValue()));
+            LocalDateTime stubbedLastSunday = LocalDateTime.of(LocalDate.of(2017, 3, 19), LocalTime.MAX);
+            DateTime lastSunday = new DateTime(stubbedLastSunday);
             lastSunday.setClock(fixedClock);
             assertFalse(lastSunday.isCurrentWeek());
-
         } catch (IllegalValueException e) {
             fail("Exception should not be thrown.");
         }


### PR DESCRIPTION
This fixes the current broken test cases that were caused by not taking into account `LocalTime` for `isCurrentWeek()` implementation.

Merge this ASAP to pass the test cases on your own branches! 😅 