### PR TITLE
Fix bug that breaks UI after sorting

### DIFF
--- a/src/main/java/seedu/opus/model/ModelManager.java
+++ b/src/main/java/seedu/opus/model/ModelManager.java
@@ -117,7 +117,8 @@ public class ModelManager extends ComponentManager implements Model {
     //@@author A0148081H
     @Override
     public void sortList(String keyword) {
-        filteredTasks = new FilteredList<>(this.taskManager.getSortedList(keyword));
+        taskManager.sortTasks(keyword);
+        indicateTaskManagerChanged();
     }
     //@@author
 

--- a/src/main/java/seedu/opus/model/ReadOnlyTaskManager.java
+++ b/src/main/java/seedu/opus/model/ReadOnlyTaskManager.java
@@ -17,12 +17,6 @@ public interface ReadOnlyTaskManager {
     ObservableList<ReadOnlyTask> getTaskList();
 
     /**
-     * Returns an unmodifiable view of the sorted tasks list.
-     * This list will not contain any duplicate tasks.
-     */
-    ObservableList<ReadOnlyTask> getSortedList(String keyword);
-
-    /**
      * Returns an unmodifiable view of the tags list.
      * This list will not contain any duplicate tags.
      */

--- a/src/main/java/seedu/opus/model/TaskManager.java
+++ b/src/main/java/seedu/opus/model/TaskManager.java
@@ -147,6 +147,15 @@ public class TaskManager implements ReadOnlyTaskManager {
         }
     }
 
+    /**
+     * Sorts the tasks based on the given keyword.
+     *
+     * @param keyword to sort the tasks by
+     */
+    public void sortTasks(String keyword) {
+        tasks.sortList(keyword);
+    }
+
 //// tag-level operations
 
     public void addTag(Tag t) throws UniqueTagList.DuplicateTagException {
@@ -165,13 +174,6 @@ public class TaskManager implements ReadOnlyTaskManager {
     public ObservableList<ReadOnlyTask> getTaskList() {
         return new UnmodifiableObservableList<>(tasks.asObservableList());
     }
-
-    //@@author A0148081H
-    @Override
-    public ObservableList<ReadOnlyTask> getSortedList(String keyword) {
-        return new UnmodifiableObservableList<>(tasks.asSortedList(keyword));
-    }
-    //@@author
 
     @Override
     public ObservableList<Tag> getTagList() {

--- a/src/main/java/seedu/opus/model/task/UniqueTaskList.java
+++ b/src/main/java/seedu/opus/model/task/UniqueTaskList.java
@@ -101,8 +101,8 @@ public class UniqueTaskList implements Iterable<Task> {
         return new UnmodifiableObservableList<>(internalList);
     }
 
-    //@@author A0148081H
-    public UnmodifiableObservableList<Task> asSortedList(String keyword) {
+    // Sorts the internal task list based on the input keyword.
+    public void sortList(String keyword) {
         switch (keyword) {
         case SortCommand.ALL:
             FXCollections.sort(internalList, new TaskComparator());
@@ -122,9 +122,7 @@ public class UniqueTaskList implements Iterable<Task> {
         default:
             break;
         }
-        return new UnmodifiableObservableList<>(internalList);
     }
-    //@@author
 
     @Override
     public Iterator<Task> iterator() {

--- a/src/main/java/seedu/opus/storage/XmlSerializableTaskManager.java
+++ b/src/main/java/seedu/opus/storage/XmlSerializableTaskManager.java
@@ -60,20 +60,6 @@ public class XmlSerializableTaskManager implements ReadOnlyTaskManager {
     }
 
     @Override
-    public ObservableList<ReadOnlyTask> getSortedList(String keyword) {
-        final ObservableList<Task> tasks = this.tasks.stream().map(p -> {
-            try {
-                return p.toModelType();
-            } catch (IllegalValueException e) {
-                e.printStackTrace();
-                //TODO: better error handling
-                return null;
-            }
-        }).collect(Collectors.toCollection(FXCollections::observableArrayList));
-        return new UnmodifiableObservableList<>(tasks);
-    }
-
-    @Override
     public ObservableList<Tag> getTagList() {
         final ObservableList<Tag> tags = this.tags.stream().map(t -> {
             try {

--- a/src/test/java/seedu/opus/model/TaskManagerTest.java
+++ b/src/test/java/seedu/opus/model/TaskManagerTest.java
@@ -88,11 +88,6 @@ public class TaskManagerTest {
         }
 
         @Override
-        public ObservableList<ReadOnlyTask> getSortedList(String keyword) {
-            return tasks;
-        }
-
-        @Override
         public ObservableList<Tag> getTagList() {
             return tags;
         }


### PR DESCRIPTION
Problem was that `filteredTasks` is observed by a lot of different components. Once we create a new instance, it breaks free from all observers.

Solved by sorting the `internalList` in `UniqueTaskList` and raising an event when we mutate the `TaskManager`. 